### PR TITLE
chore(providers): update google and google beta version

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -3,11 +3,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4, < 5"
+      version = ">= 5, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4, < 5"
+      version = ">= 5, < 8"
     }
   }
 

--- a/examples/remote/versions.tf
+++ b/examples/remote/versions.tf
@@ -3,11 +3,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4, < 5"
+      version = ">= 5, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4, < 5"
+      version = ">= 5, < 8"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,11 +3,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4, < 8"
+      version = ">= 5, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4, < 8"
+      version = ">= 5, < 8"
     }
   }
 


### PR DESCRIPTION
This pull request updates the required versions for the `google` and `google-beta` Terraform providers across multiple configuration files. The minimum supported version is now `5`, ensuring compatibility with newer provider features and APIs.

Provider version requirements update:

* Updated the `google` and `google-beta` provider version constraints from `>= 4` to `>= 5` in `versions.tf`, `examples/complete/versions.tf`, and `examples/remote/versions.tf` to require at least version 5 and support up to but not including version 8.